### PR TITLE
Fixed the docs

### DIFF
--- a/discord_components/button.py
+++ b/discord_components/button.py
@@ -62,7 +62,7 @@ class Button(Component):
     disabled: :class:`bool`
         bool: Indicates if the button is disabled.
         Defaults to ``True``.
-    emoji: :class:`discord.PartialEmoji` | :class:`str`, :class:`discord.Embed`
+    emoji: :class:`discord.PartialEmoji` | :class:`str`, :class:`discord.Emoji`
         The button's emoji.
     """
 

--- a/discord_components/client.py
+++ b/discord_components/client.py
@@ -40,7 +40,7 @@ class DiscordComponents:
         Whether to override the methods of the discord.py module.
 
         If this is enabled, you can just use
-        :class:`await <Messageable>.send`, :class:`await <Context>.send` as :class:`await <DiscordButton>.send_button_msg`,
+        :class:`await <Messageable>.send`, :class:`await <Context>.send` as :class:`await <DiscordComponents>.send_component_msg`,
         :class:`await <Message>.edit`, as :class:`await <DiscordComponents>.edit_component_msg`
         Alternatively, `on_interact` can be used.
         Defaults to ``True``.


### PR DESCRIPTION
I don't think you meant to have `discord.Embed` there as embeds don't have the attribute `animated`

## PR TYPE
> Why did you open this PR (If it is other, please write a more detailed description.)
- [ ] New feature
- [ ] Fix bug
- [x] Typo
- [ ] Other

## Checks
- [ ] Did you use the black formatter?
- [ ] Does this requires the users to change their code?
- [ ] Did you test?
- [ ] Have you updated the docs?
- [x] Can you listen to our requests?
- [ ] Did you use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)