### PR TITLE
Fix example_cog.py

### DIFF
--- a/examples/example_cog.py
+++ b/examples/example_cog.py
@@ -1,5 +1,5 @@
 from discord.ext.commands import command, Cog
-from discord_components import Button, ButtonStyle, InteractionType
+from discord_components import DiscordComponents, Button, ButtonStyle, InteractionType
 
 
 class ExampleCog(Cog):
@@ -39,4 +39,5 @@ class ExampleCog(Cog):
 
 
 def setup(bot):
+    DiscordComponents(bot)
     bot.add_cog(ExampleCog(bot))

--- a/examples/example_cog.py
+++ b/examples/example_cog.py
@@ -39,5 +39,5 @@ class ExampleCog(Cog):
 
 
 def setup(bot):
-    DiscordComponents(bot)
+    DiscordComponents(bot) # If you have this in an on_ready() event you can remove this line.
     bot.add_cog(ExampleCog(bot))


### PR DESCRIPTION
You removed the part that makes the discord-components hook and you also removed the import?
![Bruh](https://cdn.discordapp.com/attachments/847658666848682017/848637042380505148/unknown.png)

## PR TYPE
> Why did you open this PR (If it is other, please write a more detailed description.)
- [ ] New feature
- [x] Fix bug
- [ ] Typo
- [ ] Other

> Not having this fix causes:
![error](https://cdn.discordapp.com/attachments/847658666848682017/848639183274508298/unknown.png)

## Checks
- [ ] Did you use the black formatter?
- [ ] Does this requires the users to change their code?
- [x] Did you test?
- [ ] Have you updated the docs?
- [x] Can you listen to our requests?
- [ ] Did you use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)