### PR TITLE
Set discord.py minimum version to 1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-discord.py
+discord.py>=1.5


### PR DESCRIPTION
Not setting a version requirement on discord.py causes some faulty installations for users; just had to help someone out, who was getting import errors because the discord.py version which got automatically installed was one that didn't yet have `AllowedMentions`
```
Name: discord.py
Version: 1.3.4
Summary: A Python wrapper for the Discord API
Home-page: https://github.com/Rapptz/discord.py
Author: Rapptz
Author-email: None
License: MIT
Location: \pythonsoftwarefoundation.python.3.8_qbz5n2kfra8p0\localcache\local-packages\python38\site-packages
Requires: websockets, aiohttp
Required-by: discord-components
```
This PR locks the minimum version of discord.py to 1.5


## PR TYPE
> Why did you open this PR (If it is other, please write a more detailed description.)
- [ ] New feature
- [x] Fix bug
- [ ] Typo
- [ ] Other

## Checks
- [ ] Did you use the black formatter?
- [ ] Does this requires the users to change their code?
- [ ] Did you test?
- [ ] Have you updated the docs?
- [x] Can you listen to our requests?
- [ ] Did you use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)