### PR TITLE
Fixed an error in docs of Interaction.respond()

### DIFF
--- a/discord_components/interaction.py
+++ b/discord_components/interaction.py
@@ -144,7 +144,7 @@ class Interaction:
         ----------
         type: :class:`int`
             The interaction's type. (4 ~ 6)
-            Defaults to ``6``. (InteractionType.ChannelMessageWithSource)
+            Defaults to ``4``. (InteractionType.ChannelMessageWithSource)
         content: Optional[:class:`str`]
             The response message's content.
         embed: Optional[:class:`discord.Embed`]


### PR DESCRIPTION
Docs said that the type defaulted to `6` while in reality, it defaulted to `4`

## PR TYPE
> Why did you open this PR (If it is other, please write a more detailed description.)
- [ ] New feature
- [ ] Fix bug
- [x] Typo
- [ ] Other

## Checks
- [ ] Did you use the black formatter?
- [ ] Does this requires the users to change their code?
- [ ] Did you test?
- [x] Have you updated the docs?
- [x] Can you listen to our requests?
- [ ] Did you use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)