### PR TITLE
 Added a GitHub Actions workflow for Black Formatter.

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,36 @@
+name: Black Formatter
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  apply-black:
+    if: contains(github.event.commits.*.message,'GitHub Actions - Formatted using black formatter.') == false
+    name: Apply Black Formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false 
+        fetch-depth: 0 
+    - name: Run Black
+      uses: lgeiger/black-action@master
+      with:
+        args: .
+    - name: Import GPG key
+      id: import_gpg
+      uses: crazy-max/ghaction-import-gpg@v3
+      with:
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSWORD }}
+        git-user-signingkey: true
+        git-commit-gpgsign: true
+    - name: Git config
+      run: |
+        git config --local remote.origin.url "https://${{ secrets.PAT }}@github.com/${{ github.repository }}.git"
+    - name: Commit files
+      run: git commit -S -am 'GitHub Actions - Formatted using black formatter.'
+    - name: Push changes
+      run: git push origin main 


### PR DESCRIPTION
# Added a GitHub Actions workflow for Black Formatter. 

## Why?
This is useful to format unformatted code from PRs. Also useful for times when people just forget to format code. 

## Required secrets:
- `GPG_PRIVATE_KEY`: The private key for the GPG ID you want to use to sign commits.
- `GPG_PASSWORD`: The password for said GPG ID
- `PAT`: The personal access token with the read/write repo scope of the GitHub account you intend on committing from. Creating a new service account is recommended. Said account should also have the used GPG ID connected.

## Extras
This workflow usually takes less than a minute to finish running. It is free for public repositories after all.

## PR TYPE
> Why did you open this PR (If it is other, please write a more detailed description.)
- [ ] New feature
- [ ] Fix bug
- [ ] Typo
- [x] Other

## Checks
- [ ] Did you use the black formatter?
- [ ] Does this requires the users to change their code?
- [x] Did you test?
- [ ] Have you updated the docs?
- [x] Can you listen to our requests?
- [ ] Did you use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)