### PR TITLE
Use 'if embed is not None'

### DIFF
--- a/discord_components/client.py
+++ b/discord_components/client.py
@@ -91,7 +91,7 @@ class DiscordComponents:
         state = self.bot._get_state()
         channel = await channel._get_channel()
 
-        if embed:
+        if embed is not None:
             embed = embed.to_dict()
 
         if allowed_mentions is not None:
@@ -184,7 +184,7 @@ class DiscordComponents:
         if content is not None:
             data["content"] = content
 
-        if embed:
+        if embed is not None:
             embed = embed.to_dict()
             data["embed"] = embed
 


### PR DESCRIPTION
Using `if embed` calls the embed's `__len__` method, which, for me, was throwing the following error:

```py
Traceback (most recent call last):
  File "/root/enviroments/DiscordBot/events/errorhandler.py", line 597, in on_command_error
    raise error
  File "/root/enviroments/DiscordBot/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/root/enviroments/DiscordBot/commands/management.py", line 1574, in ticket_close
    await ticket_cog.close(ticket, ctx.author)
  File "/root/enviroments/DiscordBot/utils/database/manageguild_db.py", line 896, in close
    await embed.send_to(self.bot, channel)
  File "/root/enviroments/DiscordBot/utils/dpy.py", line 412, in send_to
    return await destination.send(content, **kwargs)
  File "/root/enviroments/DiscordBot/lib/python3.8/site-packages/discord_components/client.py", line 48, in send_component_msg_prop
    return await self.send_component_msg(ctxorchannel, *args, **kwargs)
  File "/root/enviroments/DiscordBot/lib/python3.8/site-packages/discord_components/client.py", line 94, in send_component_msg
    if embed:
  File "/root/enviroments/DiscordBot/lib/python3.8/site-packages/discord/embeds.py", line 206, in __len__
    total += len(footer['text'])
KeyError: 'text'
```

Using `if embed is not None` as opposed to `if embed` appears to fix the issue.

## PR TYPE
> Why did you open this PR (If it is other, please write a more detailed description.)
- [ ] New feature
- [x] Fix bug
- [ ] Typo
- [ ] Other

## Checks
- [ ] Did you use the black formatter?
- [ ] Does this requires the users to change their code?
- [x] Did you test?
- [ ] Have you updated the docs?
- [x] Can you listen to our requests?
- [x] Did you use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)