### PR TITLE
fix: rescomponent is sometimes an empty list

### DIFF
--- a/discord_components/client.py
+++ b/discord_components/client.py
@@ -288,6 +288,8 @@ class DiscordComponents:
                         rescomponent = component
         else:
             rescomponent = data["component"]
+        if not rescomponent:
+            rescomponent = data["component"]
 
         ctx = Interaction(
             bot=self.bot,

--- a/discord_components/client.py
+++ b/discord_components/client.py
@@ -49,6 +49,9 @@ class DiscordComponents:
 
         def reply_component_msg_prop(msg, *args, **kwargs):
             return self.send_component_msg(msg.channel, *args, **kwargs, reference=msg)
+        
+        def edit_component_msg_prop(msg, *args, **kwargs):
+            return self.edit_component_msg(msg, *args, **kwargs)
 
         async def on_socket_response(res):
             if (res["t"] != "INTERACTION_CREATE") or (res["d"]["type"] != 3):
@@ -66,7 +69,7 @@ class DiscordComponents:
             self.bot.on_socket_response = on_socket_response
 
         Messageable.send = send_component_msg_prop
-        Message.edit = self.edit_component_msg
+        Message.edit = sedit_component_msg_prop
         Message.reply = reply_component_msg_prop
 
     async def send_component_msg(

--- a/discord_components/client.py
+++ b/discord_components/client.py
@@ -290,7 +290,7 @@ class DiscordComponents:
                     if component.id == data["component"]["custom_id"]:
                         rescomponent = component
         if not rescomponent:
-            rescomponent = data["component"]
+            rescomponent = self._get_component_type(data["component"]["type"]).from_json(data["component"])
 
         ctx = Interaction(
             bot=self.bot,

--- a/discord_components/client.py
+++ b/discord_components/client.py
@@ -286,8 +286,6 @@ class DiscordComponents:
                 else:
                     if component.id == data["component"]["custom_id"]:
                         rescomponent = component
-        else:
-            rescomponent = data["component"]
         if not rescomponent:
             rescomponent = data["component"]
 

--- a/discord_components/client.py
+++ b/discord_components/client.py
@@ -69,7 +69,7 @@ class DiscordComponents:
             self.bot.on_socket_response = on_socket_response
 
         Messageable.send = send_component_msg_prop
-        Message.edit = sedit_component_msg_prop
+        Message.edit = edit_component_msg_prop
         Message.reply = reply_component_msg_prop
 
     async def send_component_msg(

--- a/discord_components/interaction.py
+++ b/discord_components/interaction.py
@@ -2,6 +2,7 @@ from discord import User, Client, Embed, AllowedMentions, InvalidArgument, Messa
 from discord.ext.commands import Bot
 from discord.http import Route
 
+import asyncio
 from aiohttp import FormData
 from typing import List, Union
 from json import dumps

--- a/discord_components/interaction.py
+++ b/discord_components/interaction.py
@@ -1,4 +1,4 @@
-from discord import User, Client, Embed, AllowedMentions, InvalidArgument, Message
+from discord import User, Client, Embed, AllowedMentions, InvalidArgument, Message, HTTPException
 from discord.ext.commands import Bot
 from discord.http import Route
 

--- a/discord_components/interaction.py
+++ b/discord_components/interaction.py
@@ -127,7 +127,7 @@ class Interaction:
         **options,
     ):
         state = self.bot._get_state()
-        data = {**self._get_components_json(components), **options}
+        data = {**self.client._get_components_json(components), **options}
 
         if content is not None:
             data["content"] = content

--- a/discord_components/interaction.py
+++ b/discord_components/interaction.py
@@ -122,6 +122,7 @@ class Interaction:
         content: str = None,
         *,
         embed: Embed = None,
+        embeds: List[Embed] = None,
         allowed_mentions: AllowedMentions = None,
         components: List[Union[Component, List[Component]]] = None,
         **options,
@@ -132,9 +133,15 @@ class Interaction:
         if content is not None:
             data["content"] = content
 
+        if embed is not None and embeds is not None:
+            raise ValueError('Cannot have both embed and embeds.')
+            
         if embed is not None:
             embed = embed.to_dict()
-            data["embed"] = embed
+            data["embeds"] = [embed]
+            
+        if embeds is not None:
+            data["embeds"] = [e.to_dict() for e in embeds]
 
         if allowed_mentions is not None:
             if state.allowed_mentions:
@@ -144,7 +151,6 @@ class Interaction:
 
             data["allowed_mentions"] = allowed_mentions
         
-        print(data)
         
         await self.bot.http.request(
             Route("PATCH", f"/webhooks/{self.bot.user.id}/{self.interaction_token}/messages/@original"), 

--- a/discord_components/interaction.py
+++ b/discord_components/interaction.py
@@ -143,7 +143,9 @@ class Interaction:
                 allowed_mentions = allowed_mentions.to_dict()
 
             data["allowed_mentions"] = allowed_mentions
-
+        
+        print(data)
+        
         await self.bot.http.request(
             Route("PATCH", f"/webhooks/{self.bot.user.id}/{self.interaction_token}/messages/@original"), 
             json=data

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 from os import environ
 from setuptools import setup, find_packages
 
-from discord_components import (
-    __author__ as author,
-    __version__ as tempversion,
-    __license__ as _license,
-    __name__ as name,
-)
-
 try:
     version = (
         environ["TRAVIS_TAG"].lstrip("v")
@@ -18,10 +11,10 @@ except KeyError:
     version = tempversion
 
 setup(
-    name=name,
-    version=version,
-    license=_license,
-    author=author,
+    name='discord-components',
+    version='some version',
+    license='a licence',
+    author='plun1331',
     author_email="devkiki7000@gmail.com",
     description="An unofficial library for discord components (under-development)",
     long_description=open("README.md", encoding="utf-8").read(),

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,9 @@
 from os import environ
 from setuptools import setup, find_packages
 
-try:
-    version = (
-        environ["TRAVIS_TAG"].lstrip("v")
-        if environ["TRAVIS"] == "true"
-        else environ["VERSION_NUMBER"]
-    )
-except KeyError:
-    version = tempversion
-
 setup(
     name='discord-components',
-    version='some version',
+    version='1.0.0',
     license='a licence',
     author='plun1331',
     author_email="devkiki7000@gmail.com",


### PR DESCRIPTION
This is caused by the library not being able to retrieve a component from the message, resulting in it not modifying the `rescomponent` in [`_get_interaction`](https://github.com/kiki7000/discord.py-components/blob/634c66182f654124b3f460957a89190959cef273/discord_components/client.py#L272) and it staying as an empty list.

## PR TYPE
> Why did you open this PR (If it is other, please write a more detailed description.)
- [ ] New feature
- [x] Fix bug
- [ ] Typo
- [ ] Other

## Checks
- [ ] Did you use the black formatter?
- [ ] Does this requires the users to change their code?
- [x] Did you test?
- [ ] Have you updated the docs?
- [x] Can you listen to our requests?
- [x] Did you use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)